### PR TITLE
Enable asserts in cmake relwithdebinfo build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,14 @@ ENDIF(NOT CMAKE_BUILD_TYPE)
 
 # -DNDEBUG purposely omitted because we want assertions in RelWithDebInfo mode
 #
+if(CMAKE_COMPILER_IS_GNUCC)
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Og -g"
+	  CACHE STRING "Flags used by the compiler during release builds with debug info.")
+else()
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g"
+	  CACHE STRING "Flags used by the compiler during release builds with debug info.")
+endif()
+
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Og -g" CACHE STRING 
 	"Flags used by the compiler during release builds with debug info." 
 	FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,12 @@ IF(NOT CMAKE_BUILD_TYPE)
       FORCE)
 ENDIF(NOT CMAKE_BUILD_TYPE)
 
+# -DNDEBUG purposely omitted because we want assertions in RelWithDebInfo mode
+#
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Og -g" CACHE STRING 
+	"Flags used by the compiler during release builds with debug info." 
+	FORCE)
+
 # Option handling
 #
 option(HARP_BUILD_PYTHON "build Python interface" OFF)


### PR DESCRIPTION
We use assertions in many places to prevent running under invalid pre-conditions.
The current default cmake (release-)build optimizes them away however.
This re-enables them in this mode.