### PR TITLE
Fix spelling errors found with codespell.

### DIFF
--- a/libharp/harp-binning.c
+++ b/libharp/harp-binning.c
@@ -912,7 +912,7 @@ static int find_matching_cells_and_weights_for_bounds(harp_variable *latitude_bo
         goto error;
     }
     /* the temporary polygon is used for calculating the overlap fraction with a cell */
-    /* it needs to be able to hold three times the amout of points as the input polygon */
+    /* it needs to be able to hold three times the amount of points as the input polygon */
     temp_poly_latitude = malloc(3 * (max_num_vertices + 3) * sizeof(double));
     if (temp_poly_latitude == NULL)
     {
@@ -1048,7 +1048,7 @@ static int find_matching_cells_and_weights_for_bounds(harp_variable *latitude_bo
                 max_lon_id[j] = -1;
             }
 
-            /* iterate over all line segements and determine which grid cells are crossed */
+            /* iterate over all line segments and determine which grid cells are crossed */
             /* we initially add each crossing cell with weight 1 */
             harp_interpolate_find_index(num_latitude_edges, latitude_edges, poly_latitude[0], &lat_id);
             if (lat_id == num_latitude_edges)

--- a/libharp/harp-chemistry.c
+++ b/libharp/harp-chemistry.c
@@ -234,7 +234,7 @@ harp_chemical_species harp_chemical_species_from_variable_name(const char *varia
 }
 
 /** Convert a partial column profile to a density profile using the altitude boundaries as provided
- * This is a generic routine to convert partial columns to a densitity profile. It works for all cases where the
+ * This is a generic routine to convert partial columns to a density profile. It works for all cases where the
  * conversion is a matter of dividing the partial column value by the altitude height to get the density value.
  * \param partial_column Partial column [?]
  * \param altitude_bounds Lower and upper altitude [m] boundaries [2]
@@ -348,7 +348,7 @@ double harp_number_density_from_volume_mixing_ratio(double volume_mixing_ratio, 
 }
 
 /** Convert a density to a partial column using the altitude boundaries
- * This is a generic routine to convert a densitity to a partial column. It works for all cases where the conversion
+ * This is a generic routine to convert a density to a partial column. It works for all cases where the conversion
  * is a matter of multiplying the density by the altitude height to get the partial column value.
  * \param density Density profile [?/m]
  * \param altitude_bounds Lower and upper altitude [m] boundaries [2]

--- a/libharp/harp-dataset.c
+++ b/libharp/harp-dataset.c
@@ -250,7 +250,7 @@ static int add_directory(harp_dataset *dataset, const char *pathname, const char
  */
 
 /** Create new HARP dataset.
- * The metadata will be intialized with zero product metadata elements.
+ * The metadata will be initialized with zero product metadata elements.
  * \param new_dataset Pointer to the C variable where the new HARP product metadata will be stored.
  * \return
  *   \arg \c 0, Success.

--- a/libharp/harp-derived-variable.c
+++ b/libharp/harp-derived-variable.c
@@ -1030,7 +1030,7 @@ int harp_variable_conversion_set_source_description(harp_variable_conversion *co
  * \param variable_name Name of the target variable for which to show conversions (can be NULL).
  * \param print Reference to a printf compatible function.
  * \return
- *   \arg \c  0, Succes.
+ *   \arg \c  0, Success.
  *   \arg \c -1, Error occurred (check #harp_errno).
  */
 LIBHARP_API int harp_doc_list_conversions(const harp_product *product, const char *variable_name,

--- a/libharp/harp-errno.c
+++ b/libharp/harp-errno.c
@@ -414,7 +414,7 @@ LIBHARP_API int harp_report_warning(const char *message, ...)
  * If no warning handler was set, the NULL pointer will be returned.
  * \param print Pointer to the variable in which the reference to the vprintf compatible function will be stored
  * \return
- *   \arg \c  0, Succes.
+ *   \arg \c  0, Success.
  *   \arg \c -1, Error occurred (check #harp_errno).
  */
 LIBHARP_API int harp_get_warning_handler(int (**print) (const char *, va_list ap))
@@ -443,7 +443,7 @@ LIBHARP_API int harp_get_warning_handler(int (**print) (const char *, va_list ap
  * The warning handler can be set before a call to harp_init() is made.
  * \param print Reference to a vprintf compatible function.
  * \return
- *   \arg \c  0, Succes.
+ *   \arg \c  0, Success.
  *   \arg \c -1, Error occurred (check #harp_errno).
  */
 LIBHARP_API int harp_set_warning_handler(int (*print) (const char *, va_list ap))

--- a/libharp/harp-geometry-sphere-polygon.c
+++ b/libharp/harp-geometry-sphere-polygon.c
@@ -935,7 +935,7 @@ int harp_spherical_polygon_overlapping_fraction(const harp_spherical_polygon *po
                             }
                             else
                             {
-                                /* line segements are on the same great circle, so no intermediate point needed */
+                                /* line segments are on the same great circle, so no intermediate point needed */
                                 num_intersection_points--;
                                 polygon_intersect->numberofpoints--;
                             }

--- a/libharp/harp-hdf5.c
+++ b/libharp/harp-hdf5.c
@@ -76,7 +76,7 @@ typedef struct hdf5_object_id_struct
 } hdf5_object_id;
 
 /* List of HDF5 identifiers and sizes for each physical dimension.
- * The validity flag is needed because there is no obvious way to represent an unintialized hdf5_object_id,
+ * The validity flag is needed because there is no obvious way to represent an uninitialized hdf5_object_id,
  * since in principle all combinations of fileno and addr could be valid.
  */
 typedef struct hdf5_dimension_ids_struct

--- a/libharp/harp-ingest-cci_l3_cloud.c
+++ b/libharp/harp-ingest-cci_l3_cloud.c
@@ -793,7 +793,7 @@ static void register_fields_for_daily_l3u_cloud_data(void)
     harp_variable_definition_add_mapping(variable_definition, NULL, NULL, path, description);
 }
 
-/* Code specific for montly data */
+/* Code specific for monthly data */
 
 static int ingestion_monthly_l3c_init(const harp_ingestion_module *module, coda_product *product,
                                       const harp_ingestion_options *options, harp_product_definition **definition,

--- a/libharp/harp-ingest-ecmwf-grib.c
+++ b/libharp/harp-ingest-ecmwf-grib.c
@@ -104,7 +104,7 @@ typedef enum grib_parameter_enum
     grib_param_c3h8,    /* 217047: Propane [kg/kg] */
     grib_param_tc_ch4,  /* 218004: Total column methane [kg/m2] */
     grib_param_tc_hno3, /* 218006: Total column nitric acid [kg/m2] */
-    grib_param_tc_pan,  /* 218013: Total colunn peroxyacetyl nitrate [kg/m2] */
+    grib_param_tc_pan,  /* 218013: Total column peroxyacetyl nitrate [kg/m2] */
     grib_param_tc_c5h8, /* 218016: Total column isoprene [kg/m2] */
     grib_param_tc_no,   /* 218027: Total column nitrogen oxide [kg/m2] */
     grib_param_tc_oh,   /* 218030: Total column hydroxyl radical [kg/m2] */
@@ -2044,7 +2044,7 @@ static int get_lat_lon_grid(coda_cursor *cursor, int grib_version, ingest_info *
         }
         if (info->grid_grib_version != grib_version)
         {
-            /* since GRIB1 and GRIB2 use different resolutions we need to compare with a tollerance of 1000 */
+            /* since GRIB1 and GRIB2 use different resolutions we need to compare with a tolerance of 1000 */
             if (fabs((double)longitudeOfFirstGridPoint - (double)info->longitudeOfFirstGridPoint) > 1e3 ||
                 fabs((double)longitudeOfLastGridPoint - (double)info->longitudeOfLastGridPoint) > 1e3 ||
                 fabs((double)iDirectionIncrement - (double)info->iDirectionIncrement) > 1e3)
@@ -3674,7 +3674,7 @@ int harp_ingestion_module_ecmwf_grib_init(void)
                                "(discipline,category,number) = (192,218,6)");
 
     /* tc_pan: C2H3NO5_column_density */
-    description = "total colunn peroxyacetyl nitrate";
+    description = "total column peroxyacetyl nitrate";
     variable_definition = harp_ingestion_register_variable_block_read(product_definition, "C2H3NO5_column_density",
                                                                       harp_type_float, 2, &dimension_type[1], NULL,
                                                                       description, "kg/m^2", include_tc_pan,

--- a/libharp/harp-ingest-gome2_l1.c
+++ b/libharp/harp-ingest-gome2_l1.c
@@ -2168,7 +2168,7 @@ static harp_product_definition *register_measurement_product(harp_ingestion_modu
         "4, 2, or 1 measurement(s) respectively for this band in a scan. ";
     harp_product_definition_add_mapping(product_definition, description, NULL);
     description = "Some readouts may even cover multiple scans if the integration time is larger than 6s. HARP will "
-        "combine the data for all bands into a single two-dimensional pixel_readout array and uses a fixed resulotion "
+        "combine the data for all bands into a single two-dimensional pixel_readout array and uses a fixed resolution "
         "of 187.5ms for the variables. Because bands might have higher integration time this means that for those "
         "bands there will be multiple rows in the pixel_readout array for a single readout. ";
     harp_product_definition_add_mapping(product_definition, description, NULL);

--- a/libharp/harp-ingest-gome2_l2.c
+++ b/libharp/harp-ingest-gome2_l2.c
@@ -3654,7 +3654,7 @@ static void register_common_variables(harp_product_definition *product_definitio
                                                    include_surface_albedo, read_surface_albedo);
     path = "/DETAILED_RESULTS/SurfaceAlbedo[,window], /META_DATA/MainSpecies[]";
     description =
-        "window is the index in MainSpecies[] that has the value for which the detailed_restults opion is set";
+        "window is the index in MainSpecies[] that has the value for which the detailed_results option is set";
     harp_variable_definition_add_mapping(variable_definition, "detailed_results set", "CODA product version >= 3", path,
                                          description);
 

--- a/libharp/harp-ingest-s5p_l2.c
+++ b/libharp/harp-ingest-s5p_l2.c
@@ -3123,7 +3123,7 @@ static int read_o3_pr_ozone_profile_apriori_covariance(void *user_data, harp_arr
                 }
                 else
                 {
-                    /* since the matrix is symetric, use the value from the lower triangular part of the matrix */
+                    /* since the matrix is symmetric, use the value from the lower triangular part of the matrix */
                     value = data.float_data[offset + k * num_levels + j];
                 }
                 data.float_data[offset + j * num_levels + k] = (float)value;
@@ -3263,7 +3263,7 @@ static int read_o3_tcl_ozone_stratospheric_vertical_column(void *user_data, harp
         {
             return -1;
         }
-        /* replicate values accross longitude dimension */
+        /* replicate values across longitude dimension */
         for (i = info->num_latitudes - 1; i >= 0; i--)
         {
             float value = data.float_data[i];
@@ -3292,7 +3292,7 @@ static int read_o3_tcl_ozone_stratospheric_vertical_column_precision(void *user_
         {
             return -1;
         }
-        /* replicate values accross longitude dimension */
+        /* replicate values across longitude dimension */
         for (i = info->num_latitudes - 1; i >= 0; i--)
         {
             float value = data.float_data[i];

--- a/libharp/harp-ingest-sciamachy_l2.c
+++ b/libharp/harp-ingest-sciamachy_l2.c
@@ -2437,7 +2437,7 @@ static void register_common_limb_variables(harp_product_definition *product_defi
                                                                       harp_type_double, 3, dimension_type,
                                                                       bounds_dimension, description, "km", NULL,
                                                                       read_altitude_bounds);
-    description = "the tangent heights are the lower bound altitudes; for the top of the heighest layer a TOA value "
+    description = "the tangent heights are the lower bound altitudes; for the top of the highest layer a TOA value "
         "of 100km is used";
     snprintf(path, MAX_PATH_LENGTH, "/%s[]/tangent_height[]", dataset);
     harp_variable_definition_add_mapping(variable_definition, NULL, NULL, path, description);
@@ -2449,7 +2449,7 @@ static void register_common_limb_variables(harp_product_definition *product_defi
                                                                       bounds_dimension, description, "hPa", NULL,
                                                                       read_pressure_bounds);
     snprintf(path, MAX_PATH_LENGTH, "/%s[]/tangent_pressure[]", dataset);
-    description = "the tangent pressures are the lower bound pressures; for the top of the heighest layer a pressure "
+    description = "the tangent pressures are the lower bound pressures; for the top of the highest layer a pressure "
         "value of 3.2e-4 hPa is used";
     harp_variable_definition_add_mapping(variable_definition, NULL, NULL, path, description);
 

--- a/libharp/harp-ingest-smr_l2.c
+++ b/libharp/harp-ingest-smr_l2.c
@@ -254,7 +254,7 @@ static int enable_include_for_species_in_file(ingest_info *info)
     /* We can't read the speciesname with with coda_cursor_read_string  */
     /* because that yields a 1-char string and cursor_read_array fails  */
     /* because the type is text and not an array. Also, the size of the */
-    /* name varies. Therefor we first get the size and read size chars. */
+    /* name varies. Therefore we first get the size and read size chars. */
     if (coda_cursor_get_array_dim(&cursor, &num_dims, dims) != 0)
     {
         harp_set_error(HARP_ERROR_CODA, NULL);

--- a/libharp/harp-internal.h
+++ b/libharp/harp-internal.h
@@ -47,7 +47,7 @@
 
 #include <stdarg.h>
 
-/* make sure that math.h on Windows als includes the defines for e.g. M_PI */
+/* make sure that math.h on Windows also includes the defines for e.g. M_PI */
 #define _USE_MATH_DEFINES
 
 /* This defines the amount of items that will be allocated per block for an auto-growing array (using realloc) */
@@ -56,7 +56,7 @@
 /* Maximum number of source variables that can be used to create derived variables */
 #define MAX_NUM_SOURCE_VARIABLES 10
 
-/* floating point precission */
+/* floating point precision */
 #define EPSILON 1e-10
 
 /* maximum length for file paths */

--- a/libharp/harp-product-metadata.c
+++ b/libharp/harp-product-metadata.c
@@ -69,7 +69,7 @@ LIBHARP_API void harp_product_metadata_delete(harp_product_metadata *metadata)
 
 /**
  * Create new product metadata.
- * The metadata will be intialized with 0.0 datetime_start/end.
+ * The metadata will be initialized with 0.0 datetime_start/end.
  * \param new_metadata Pointer to the C variable where the new HARP product metadata will be stored.
  * \return
  *   \arg \c 0, Success.

--- a/libharp/harp-product.c
+++ b/libharp/harp-product.c
@@ -45,7 +45,7 @@
  *
  * The representation of a HARP product in C is a structure containing:
  * - an array of variables
- * - an array of dimension lengths for each dimension type (unvailable dimensions have length -1)
+ * - an array of dimension lengths for each dimension type (unavailable dimensions have length -1)
  * - the `source_product` global attribute (can be NULL)
  * - the `history` global attribute (can be NULL)
  *
@@ -789,7 +789,7 @@ int harp_product_get_storage_size(const harp_product *product, int with_attribut
  */
 
 /** Create new product.
- * The product will be intialized with 0 variables and 0 attributes.
+ * The product will be initialized with 0 variables and 0 attributes.
  * \param new_product Pointer to the C variable where the new HARP product will be stored.
  * \return
  *   \arg \c 0, Success.

--- a/libharp/harp-regrid.c
+++ b/libharp/harp-regrid.c
@@ -892,7 +892,7 @@ LIBHARP_API int harp_product_regrid_with_axis_variable(harp_product *product, ha
                 }
             }
         }
-        /* Als make variable time dependent if the grid dimension is time and the variable does not depend on time */
+        /* Also make variable time dependent if the grid dimension is time and the variable does not depend on time */
         if (dimension_type == harp_dimension_time &&
             (variable->num_dimensions == 0 || variable->dimension_type[0] != harp_dimension_time))
         {

--- a/libharp/harp-variable.c
+++ b/libharp/harp-variable.c
@@ -1512,7 +1512,7 @@ LIBHARP_API int harp_variable_copy(const harp_variable *other_variable, harp_var
 /** Copy all attributes of a variable to a target variable.
  * This will copy all attribute information of a variable that is not available as a parameter of \a harp_variable_new.
  * \param variable Variable from which the attributes should be copied.
- * \param target_variable Variable into which the attribtes will be stored.
+ * \param target_variable Variable into which the attributes will be stored.
  * \return
  *   \arg \c 0, Success.
  *   \arg \c -1, Error occurred (check #harp_errno).

--- a/libharp/harp-vertical-profiles.c
+++ b/libharp/harp-vertical-profiles.c
@@ -646,7 +646,7 @@ void harp_profile_pressure_from_gph(long num_levels, const double *gph_profile, 
     }
 }
 
-/** Sum the columns of the 2D averaging kernal to arrive at a 1D column averaging kernel
+/** Sum the columns of the 2D averaging kernel to arrive at a 1D column averaging kernel
  * The 2D averaging kernel needs to be a partial column number density AVK.
  * \param num_levels            Number of vertical levels
  * \param column_density_avk_2d 2D column number density averaging kernel {num_levels,num_levels}
@@ -1553,7 +1553,7 @@ LIBHARP_API int harp_product_smooth_vertical_with_collocated_dataset(harp_produc
  * \param name Name of the variable that should be created.
  * \param unit Unit (optional) of the variable that should be created.
  * \param vertical_grid Variable containing the vertical grid of the column avk.
- * \param vertical_bounds Variable containig the grid boundaries of the column avk (optional).
+ * \param vertical_bounds Variable containing the grid boundaries of the column avk (optional).
  * \param column_avk Column averaging kernel variable.
  * \param apriori Apriori profile (optional).
  * \param variable Pointer to the C variable where the derived HARP variable will be stored.

--- a/libharp/harp-vertical-profiles.h
+++ b/libharp/harp-vertical-profiles.h
@@ -84,10 +84,10 @@ double harp_profile_strato_column_from_partial_column_and_pressure(long num_leve
 void harp_profile_column_avk_from_partial_column_avk(long num_levels, const double *column_density_avk_2d,
                                                      double *column_density_avk_1d);
 void harp_profile_tropospheric_column_avk_from_column_avk(long num_levels, const double *column_density_avk,
-                                                          const double *altitude_bounds, double tropopuase_altitude,
+                                                          const double *altitude_bounds, double tropopause_altitude,
                                                           double *tropospheric_column_density_avk);
 void harp_profile_stratospheric_column_avk_from_column_avk(long num_levels, const double *column_density_avk,
-                                                           const double *altitude_bounds, double tropopuase_altitude,
+                                                           const double *altitude_bounds, double tropopause_altitude,
                                                            double *stratospheric_column_density_avk);
 void harp_density_avk_from_partial_column_avk_and_altitude_bounds(long num_levels, const double *partial_column_avk,
                                                                   const double *altitude_bounds, double *density_avk);

--- a/libharp/harp.c
+++ b/libharp/harp.c
@@ -207,7 +207,7 @@ static int auxiliary_data_init(void)
  * If multiple files for the same product class exist in the path, CODA will only use the one with the highest revision
  * number (this is normally equal to a last modification date that is stored in a .codadef file).
  * If there are two files for the same product class with identical revision numbers, CODA will use the definitions of
- * the first .codadef file in the path and ingore the second one.
+ * the first .codadef file in the path and ignore the second one.
  *
  * Specifying a path using this function will prevent CODA from using the CODA_DEFINITION environment variable.
  * If you still want CODA to acknowledge the CODA_DEFINITION environment variable then use something like this in your
@@ -719,7 +719,7 @@ LIBHARP_API int harp_import_test(const char *filename, int (*print) (const char 
  * string of key=value pair; only used if the file is not in HARP format.
  * \param new_metadata Pointer to the variable where the metadata should be stored.
  * \return
- *   \arg \c 0, Succes.
+ *   \arg \c 0, Success.
  *   \arg \c -1, Error occurred (check #harp_errno).
  */
 LIBHARP_API int harp_import_product_metadata(const char *filename, const char *options,


### PR DESCRIPTION
```
codespell --version
1.16.0
```

Only checked `libharp/*.[chly]`

Did not fix #228 as I wasn't 100% sure what the fix would be.