### PR TITLE
Fix uninitialized read in harp_operation_string_comparison_filter_new

### DIFF
--- a/libharp/harp-operation.c
+++ b/libharp/harp-operation.c
@@ -3327,6 +3327,7 @@ int harp_operation_string_comparison_filter_new(const char *variable_name, harp_
     operation->eval = eval_string_comparison;
     operation->variable_name = NULL;
     operation->operator_type = operator_type;
+    operation->value = NULL;
 
     operation->variable_name = strdup(variable_name);
     if (operation->variable_name == NULL)


### PR DESCRIPTION
This code malloc's a `harp_operation_string_comparison_filter` and then
directly initializes all fields aside from `value`. Afterwards it tries to
`strdup` `variable_name` and if that fails (due to a out-of-memory error) it
will error out and cleanup the allocated struct via
`string_comparison_filter_delete`.

`string_comparison_filter_delete` does the following check on the passed in
struct where it will free the memory behind `value` if it's not NULL:

```
        if (operation->value != NULL)
        {
            free(operation->value);
        }
```

However, because `value` is not initialized yet, this code actually randomly
calls free with the uninitialized pointer value as the argument.