### PR TITLE
Optimize polygon check

### DIFF
--- a/libharp/harp-geometry-sphere-line.c
+++ b/libharp/harp-geometry-sphere-line.c
@@ -189,11 +189,13 @@ static int8_t point_on_line(const harp_vector3d *line_begin, const harp_vector3d
  * or are equal. Returns 0 for connected lines, which are lines where one of
  * the points are equal, and for separate lines.
  *
- * Parameters:
- * p11: the starting point of first line
- * p12: the end point of first line
- * p21: the starting point of second line
- * p22: the end point of second line
+ * \param p11 the starting point of first line
+ * \param p12 the end point of first line
+ * \param p21 the starting point of second line
+ * \param p22 the end point of second line
+ * \return
+ *   \arg \c 1, Lines intersect or are equal
+ *   \arg \c 0, Lines are separate or connected
  */
 int8_t harp_spherical_line_intersects(const harp_spherical_point *p11, const harp_spherical_point *p12,
                             const harp_spherical_point *p21, const harp_spherical_point *p22)

--- a/libharp/harp-geometry-sphere-polygon.c
+++ b/libharp/harp-geometry-sphere-polygon.c
@@ -205,11 +205,10 @@ static int spherical_line_segment_from_polygon(harp_spherical_line *line, const 
  */
 int harp_spherical_polygon_check(const harp_spherical_polygon *polygon)
 {
-    harp_spherical_line linei, linek;
     harp_vector3d vector;
     harp_spherical_point point;
+    const harp_spherical_point *p11, *p12, *p21, *p22;
     harp_euler_transformation se;
-    int8_t relationship;        /* Relationship between lines */
     int32_t i, k;
 
     /* Centre should not correspond to 0-vector */
@@ -224,19 +223,24 @@ int harp_spherical_polygon_check(const harp_spherical_polygon *polygon)
     /* Line segments should not cross each other */
     for (i = 0; i < polygon->numberofpoints; i++)
     {
-        /* Grab line segment from polygon */
-        spherical_line_segment_from_polygon(&linei, polygon, i);
-
         for (k = (i + 1); k < polygon->numberofpoints; k++)
         {
-            /* Grab line segment from polygon */
-            spherical_line_segment_from_polygon(&linek, polygon, k);
+            /* the first edge */
+            p11 = polygon->point + i;
+            p12 = polygon->point + i + 1;
 
-            /* Determine the relationship between two line segments */
-            relationship = harp_spherical_line_spherical_line_relationship(&linei, &linek);
+            /* the second edge */
+            p21 = polygon->point + k;
+            if (k == polygon->numberofpoints - 1)
+            {
+                p22 = polygon->point + 0;
+            }
+            else
+            {
+                p22 = polygon->point + k + 1;
+            }
 
-            /* Line segments should not cross each other, i.e. they should connect or avoid each other entirely */
-            if (!(relationship == HARP_GEOMETRY_LINE_CONNECTED || relationship == HARP_GEOMETRY_LINE_SEPARATE))
+            if (harp_spherical_line_intersects(p11, p12, p21, p22))
             {
                 harp_set_error(HARP_ERROR_INVALID_ARGUMENT, "invalid polygon (line segments overlap)");
                 return -1;

--- a/libharp/harp-geometry.h
+++ b/libharp/harp-geometry.h
@@ -176,6 +176,8 @@ void harp_spherical_line_end(harp_spherical_point *point, const harp_spherical_l
 int harp_spherical_point_is_at_spherical_line(const harp_spherical_point *point, const harp_spherical_line *line);
 void harp_inverse_euler_transformation_from_spherical_line(harp_euler_transformation *inverse_transformation,
                                                            const harp_spherical_line *line);
+int8_t harp_line_intersects(const harp_spherical_point *p11, const harp_spherical_point *p12,
+                            const harp_spherical_point *p21, const harp_spherical_point *p22);
 int8_t harp_spherical_line_spherical_line_relationship(const harp_spherical_line *linea,
                                                        const harp_spherical_line *lineb);
 void harp_spherical_line_from_spherical_points(harp_spherical_line *line, const harp_spherical_point *point_begin,

--- a/libharp/harp-geometry.h
+++ b/libharp/harp-geometry.h
@@ -176,7 +176,7 @@ void harp_spherical_line_end(harp_spherical_point *point, const harp_spherical_l
 int harp_spherical_point_is_at_spherical_line(const harp_spherical_point *point, const harp_spherical_line *line);
 void harp_inverse_euler_transformation_from_spherical_line(harp_euler_transformation *inverse_transformation,
                                                            const harp_spherical_line *line);
-int8_t harp_line_intersects(const harp_spherical_point *p11, const harp_spherical_point *p12,
+int8_t harp_spherical_line_intersects(const harp_spherical_point *p11, const harp_spherical_point *p12,
                             const harp_spherical_point *p21, const harp_spherical_point *p22);
 int8_t harp_spherical_line_spherical_line_relationship(const harp_spherical_line *linea,
                                                        const harp_spherical_line *lineb);


### PR DESCRIPTION
Running `harpdump` on a large dataset (~200Mb) is very slow. I did a benchmark on a query, which resulted in the following estimates:
| Command | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `./harpdump -a 'area_covers_point(-23,-122)' data.nc` | 15.250 ± 0.250 | 14.907 | 15.764 |

After running a profiler this command it was found that the program spends 83.20% of its time inside `harp_spherical_polygon_check`, which spends most of its time inside `harp_spherical_line_spherical_line_relationship`. See the following callgraph:
![harpdump-profile-unoptimized](https://user-images.githubusercontent.com/23523462/202203776-9698ebe3-79ce-4738-b3ac-21f436d7190e.png)

`harp_spherical_line_spherical_line_relationship` is used to check for self-intersection of a polygon, however, the relationship also checks for overlap, equal and connected. This function uses a lot of transformations of lines, which takes a lot of computation time.

In order to fix this I have written a new function `harp_spherical_line_intersects`, which only checks whether a line intersects or not by intersecting the great circles of the lines, i.e. the planes on which the lines lie, and then checking if the intersection point is on both lines. This is done entirely in 3D vector space and the only functions with high cost are transforming the lat/lon coordinates to XYZ coordinates. A new benchmark of the same command on the same data results in a 3x decrease in running time:
| Command | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `./harpdump -a 'area_covers_point(-23,-122)' data.nc` after optimization | 4.560 ± 0.085 | 4.453 | 4.703 |

And after again running the profiler, we now see that the program spends 20.05% of its time inside `harp_spherical_line_intersects`. Now the program spends most of its time in loading the data.
![harpdump-profile-optimized](https://user-images.githubusercontent.com/23523462/202205976-661436d4-ac13-4479-aa21-ca1923d46935.png)
